### PR TITLE
Version bump: postfixadmin 3.0 & PHP 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM alpine
+FROM php:7-alpine
 MAINTAINER Konstantin Jakobi <konstantin.jakobi@gmail.com>
 
 ENV VERSION=3.0
 
 EXPOSE 80
 
-RUN apk add --no-cache bash curl dovecot mysql-client php-imap php-mysqli \
+RUN apk add --no-cache bash curl dovecot mysql-client c-client imap-dev \
+ && docker-php-ext-install imap mysqli \
+ && apk del imap-dev \
+ && rm -rf /var/cache/apk/* \
  && curl --location https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/postfixadmin-${VERSION}.tar.gz | tar xzf - \
  && mv postfixadmin* /www \
  && mkdir /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 MAINTAINER Konstantin Jakobi <konstantin.jakobi@gmail.com>
 
-ENV VERSION=2.93
+ENV VERSION=3.0
 
 EXPOSE 80
 

--- a/php.ini
+++ b/php.ini
@@ -1,4 +1,4 @@
-error_reporting=E_ALL & ~E_NOTICE
+error_reporting=E_ALL & ~E_NOTICE & ~E_DEPRECATED
 memory_limit=128M
 upload_max_filesize=128M
 post_max_size=128M


### PR DESCRIPTION
- Upgrade to the recently released postfixadmin 3.0
- Upgrade to PHP 7.0 using the alpine based PHP core image provided by the vendor.