### PR TITLE
Security enhancement: Run web server with unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM php:7-alpine
 ENV VERSION=3.1
-EXPOSE 80
-RUN apk add --no-cache bash curl dovecot mysql-client c-client imap-dev \
+EXPOSE 8000
+RUN apk add --no-cache bash curl dovecot mysql-client c-client imap-dev su-exec \
  && docker-php-ext-install imap mysqli \
  && apk del imap-dev \
  && rm -rf /var/cache/apk/* \
  && curl --location https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/postfixadmin-${VERSION}.tar.gz \
-    | tar xzf - --one-top-level=/www --strip=1 \
+    | tar xzf - --no-same-owner --one-top-level=/www --strip=1 \
  && mkdir /config
 COPY config.php php.ini run.sh /
-CMD /run.sh
+CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apk add --no-cache bash curl dovecot mysql-client c-client imap-dev su-exec 
  && rm -rf /var/cache/apk/* \
  && curl --location https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/postfixadmin-${VERSION}.tar.gz \
     | tar xzf - --no-same-owner --one-top-level=/www --strip=1 \
+ && mkdir -p /www/templates_c \
+ && chown nobody /www/templates_c \
  && mkdir /config
 COPY config.php php.ini run.sh /
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apk add --no-cache bash curl dovecot mysql-client c-client imap-dev \
  && docker-php-ext-install imap mysqli \
  && apk del imap-dev \
  && rm -rf /var/cache/apk/* \
- && curl --location https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/postfixadmin-${VERSION}.tar.gz | tar xzf - \
- && mv postfixadmin* /www \
+ && curl --location https://downloads.sourceforge.net/project/postfixadmin/postfixadmin/postfixadmin-${VERSION}/postfixadmin-${VERSION}.tar.gz \
+    | tar xzf - --one-top-level=/www --strip=1 \
  && mkdir /config
 COPY config.php php.ini run.sh /
 CMD /run.sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PostfixAdmin Docker image
 
-[![](https://badge.imagelayers.io/konjak/postfixadmin:latest.svg)](https://imagelayers.io/?images=konjak/postfixadmin:latest)
-
 Production ready Docker container for [PostfixAdmin](http://postfixadmin.sourceforge.net/) with MySQL usage.
+
+This is a fork from [konstantinj/docker-postfixadmin](https://github.com/konstantinj/docker-postfixadmin) with a tiny security addition.
 
 ## Features - why using this image instead of several others?
 

--- a/php.ini
+++ b/php.ini
@@ -1,4 +1,6 @@
 error_reporting=E_ALL & ~E_NOTICE & ~E_DEPRECATED
+display_errors=Off
+log_errors=Off
 memory_limit=128M
 upload_max_filesize=128M
 post_max_size=128M

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cmd_php="php -S 0.0.0.0:80 -c php.ini -t /www"
-
 wait_for_mysql() {
   until mysql --host=$MYSQL_HOST --user=$MYSQL_USER --password=$MYSQL_PASSWORD --execute="USE $MYSQL_DATABASE;" &>/dev/null; do
     echo "waiting for mysql to start..."
@@ -30,7 +28,7 @@ init_config() {
 }
 
 init_db() {
-  $cmd_php &
+  php -S 127.0.0.1:80 -c php.ini -t /www &
   wait_for_php
   pid_php=$!
   setup_password="s3cr3t";
@@ -55,4 +53,10 @@ if [ ! -f .initialized ]; then
   touch .initialized
 fi
 
-$cmd_php
+
+trap 'kill -9 $(jobs -p)' EXIT
+trap 'exit' INT TERM
+
+su-exec nobody php -S 0.0.0.0:8000 -c /php.ini -t /www &
+
+wait


### PR DESCRIPTION
Despite the level of isolation Docker provides, it's a bad idea to run a web server as `root` in a container:

Bugs in either the PHP builtin web server or the postfixadmin code may allow an intruder to modify container-local files (such as the postfixadmin sources itself) and eventually alter mailbox configurations.

Therefore the exposed web server now runs as user `nobody` on an unprivileged port. Consequently, the owner of the postfixadmin sources is assured to be `root` during container build time.